### PR TITLE
Updates to variables and constants

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
             let error = run(&file, None);
 
             if let Some(err) = error {
-                log_error(&format!("{err}"));
+                println!("{err}");
             }
         }
         (None, None) => {

--- a/crates/glang-interpreter/src/values/built_in_function.rs
+++ b/crates/glang-interpreter/src/values/built_in_function.rs
@@ -19,6 +19,7 @@ use std::{
 pub struct BuiltInFunction {
     pub name: String,
     pub context: Option<Rc<RefCell<Context>>>,
+    pub is_const: bool,
     pub pos_start: Option<Position>,
     pub pos_end: Option<Position>,
 }
@@ -28,6 +29,7 @@ impl BuiltInFunction {
         BuiltInFunction {
             name: name.to_string(),
             context: None,
+            is_const: false,
             pos_start: None,
             pos_end: None,
         }

--- a/crates/glang-interpreter/src/values/function.rs
+++ b/crates/glang-interpreter/src/values/function.rs
@@ -16,6 +16,7 @@ pub struct Function {
     pub arg_names: Arc<[String]>,
     pub should_auto_return: bool,
     pub context: Option<Rc<RefCell<Context>>>,
+    pub is_const: bool,
     pub pos_start: Option<Position>,
     pub pos_end: Option<Position>,
 }
@@ -33,6 +34,7 @@ impl Function {
             arg_names: Arc::from(arg_names),
             should_auto_return,
             context: None,
+            is_const: false,
             pos_start: None,
             pos_end: None,
         }

--- a/crates/glang-interpreter/src/values/list.rs
+++ b/crates/glang-interpreter/src/values/list.rs
@@ -9,6 +9,7 @@ use std::{cell::RefCell, iter::zip, rc::Rc};
 pub struct List {
     pub elements: Vec<Value>,
     pub context: Option<Rc<RefCell<Context>>>,
+    pub is_const: bool,
     pub pos_start: Option<Position>,
     pub pos_end: Option<Position>,
 }
@@ -18,6 +19,7 @@ impl List {
         Self {
             elements,
             context: None,
+            is_const: false,
             pos_start: None,
             pos_end: None,
         }

--- a/crates/glang-interpreter/src/values/number.rs
+++ b/crates/glang-interpreter/src/values/number.rs
@@ -6,6 +6,7 @@ use std::{cell::RefCell, rc::Rc};
 pub struct Number {
     pub value: f64,
     pub context: Option<Rc<RefCell<Context>>>,
+    pub is_const: bool,
     pub pos_start: Option<Position>,
     pub pos_end: Option<Position>,
 }
@@ -15,6 +16,7 @@ impl Number {
         Self {
             value,
             context: None,
+            is_const: false,
             pos_start: None,
             pos_end: None,
         }

--- a/crates/glang-interpreter/src/values/string.rs
+++ b/crates/glang-interpreter/src/values/string.rs
@@ -9,6 +9,7 @@ use std::{cell::RefCell, rc::Rc};
 pub struct Str {
     pub value: String,
     pub context: Option<Rc<RefCell<Context>>>,
+    pub is_const: bool,
     pub pos_start: Option<Position>,
     pub pos_end: Option<Position>,
 }
@@ -18,6 +19,7 @@ impl Str {
         Str {
             value,
             context: None,
+            is_const: false,
             pos_start: None,
             pos_end: None,
         }

--- a/crates/glang-interpreter/src/values/value.rs
+++ b/crates/glang-interpreter/src/values/value.rs
@@ -81,6 +81,18 @@ impl Value {
         self.clone()
     }
 
+    pub fn set_const(&mut self, is_const: bool) -> Value {
+        match self {
+            Value::NumberValue(value) => value.is_const = is_const,
+            Value::ListValue(value) => value.is_const = is_const,
+            Value::StringValue(value) => value.is_const = is_const,
+            Value::FunctionValue(value) => value.is_const = is_const,
+            Value::BuiltInFunction(value) => value.is_const = is_const,
+        }
+
+        self.clone()
+    }
+
     pub fn perform_operation(
         &mut self,
         operator: &str,
@@ -116,6 +128,16 @@ impl Value {
             Value::StringValue(value) => value.value.is_empty(),
             Value::FunctionValue(value) => value.name.is_empty(),
             Value::BuiltInFunction(value) => value.name.is_empty(),
+        }
+    }
+
+    pub fn is_const(&self) -> bool {
+        match self {
+            Value::NumberValue(value) => value.is_const,
+            Value::ListValue(value) => value.is_const,
+            Value::StringValue(value) => value.is_const,
+            Value::FunctionValue(value) => value.is_const,
+            Value::BuiltInFunction(value) => value.is_const,
         }
     }
 

--- a/crates/glang-parser/src/nodes/ast_node.rs
+++ b/crates/glang-parser/src/nodes/ast_node.rs
@@ -5,7 +5,7 @@ use crate::nodes::{
     list_node::ListNode, number_node::NumberNode, return_node::ReturnNode, string_node::StringNode,
     try_except_node::TryExceptNode, unary_operator_node::UnaryOperatorNode,
     variable_access_node::VariableAccessNode, variable_assign_node::VariableAssignNode,
-    while_node::WhileNode,
+    variable_reassign_node::VariableRessignNode, while_node::WhileNode,
 };
 use glang_attributes::Position;
 
@@ -28,6 +28,7 @@ pub enum AstNode {
     UnaryOperator(UnaryOperatorNode),
     VariableAccess(VariableAccessNode),
     VariableAssign(VariableAssignNode),
+    VariableReassign(VariableRessignNode),
     While(WhileNode),
 }
 
@@ -51,6 +52,7 @@ impl AstNode {
             AstNode::UnaryOperator(node) => node.pos_start.clone(),
             AstNode::VariableAccess(node) => node.pos_start.clone(),
             AstNode::VariableAssign(node) => node.pos_start.clone(),
+            AstNode::VariableReassign(node) => node.pos_start.clone(),
             AstNode::While(node) => node.pos_start.clone(),
         }
     }
@@ -74,6 +76,7 @@ impl AstNode {
             AstNode::UnaryOperator(node) => node.pos_end.clone(),
             AstNode::VariableAccess(node) => node.pos_end.clone(),
             AstNode::VariableAssign(node) => node.pos_end.clone(),
+            AstNode::VariableReassign(node) => node.pos_end.clone(),
             AstNode::While(node) => node.pos_end.clone(),
         }
     }

--- a/crates/glang-parser/src/nodes/mod.rs
+++ b/crates/glang-parser/src/nodes/mod.rs
@@ -16,4 +16,5 @@ pub mod try_except_node;
 pub mod unary_operator_node;
 pub mod variable_access_node;
 pub mod variable_assign_node;
+pub mod variable_reassign_node;
 pub mod while_node;

--- a/crates/glang-parser/src/nodes/variable_reassign_node.rs
+++ b/crates/glang-parser/src/nodes/variable_reassign_node.rs
@@ -1,0 +1,22 @@
+use crate::nodes::ast_node::AstNode;
+use glang_attributes::Position;
+use glang_lexer::Token;
+
+#[derive(Debug, Clone)]
+pub struct VariableRessignNode {
+    pub var_name_token: Token,
+    pub value_node: Box<AstNode>,
+    pub pos_start: Option<Position>,
+    pub pos_end: Option<Position>,
+}
+
+impl VariableRessignNode {
+    pub fn new(var_name_token: Token, value_node: Box<AstNode>) -> Self {
+        Self {
+            var_name_token: var_name_token.to_owned(),
+            value_node,
+            pos_start: var_name_token.pos_start,
+            pos_end: var_name_token.pos_end,
+        }
+    }
+}

--- a/library/default/string.glang
+++ b/library/default/string.glang
@@ -58,8 +58,8 @@ func endswith(str, chars) {
     }
 
     # we have to reverse each string because we can't iterate backwards through a string
-    obj str = reverse_str(str);
-    obj chars = reverse_str(chars);
+    str = reverse_str(str);
+    chars = reverse_str(chars);
 
     walk i = 0 through length(chars) {
         if charat(str, i) != charat(chars, i) {

--- a/library/std/format.glang
+++ b/library/std/format.glang
@@ -17,7 +17,7 @@ func format(str, value) {
                 obj closing = charat(str, i + 1);
 
                 if closing == "}" {
-                    obj result = join(result, tostring(value));
+                    result = join(result, tostring(value));
                 } otherwise {
                     uhoh("'format' expects string with closing brackets '{}'");
                 }
@@ -29,7 +29,7 @@ func format(str, value) {
                 next;
             }
 
-            obj result = join(result, char);
+            result = join(result, char);
         }
     }
 

--- a/library/std/hashmap.glang
+++ b/library/std/hashmap.glang
@@ -14,7 +14,7 @@ func hashmap_set(hashmap_obj, key, value) {
 
         # the key exists, so remove it
         if retrieve(pair, 0) == key {
-            obj hashmap_obj = remove(hashmap_obj, i);
+            hashmap_obj = remove(hashmap_obj, i);
         }
     }
 
@@ -56,7 +56,7 @@ func hashmap_keys(hashmap_obj) {
 
     walk i = 0 through length(hashmap_obj) {
         obj pair = retrieve(hashmap_obj, i);
-        obj keys = push(keys, retrieve(pair, 0));
+        keys = push(keys, retrieve(pair, 0));
     }
 
     give keys;
@@ -69,7 +69,7 @@ func hashmap_values(hashmap_obj) {
 
     walk i = 0 through length(hashmap_obj) {
         obj pair = retrieve(hashmap_obj, i);
-        obj values = push(values, retrieve(pair, 1));
+        values = push(values, retrieve(pair, 1));
     }
 
     give values;

--- a/library/std/math.glang
+++ b/library/std/math.glang
@@ -43,11 +43,11 @@ func math_wrap_pi(x) {
     obj y = x;
 
     while y > math_pi {
-        obj y = y - (2.0 * math_pi);
+        y = y - (2.0 * math_pi);
     }
 
     while y < -math_pi {
-        obj y = y + (2.0 * math_pi);
+        y = y + (2.0 * math_pi);
     }
 
     give y;

--- a/library/std/math.glang
+++ b/library/std/math.glang
@@ -1,8 +1,8 @@
 # file math.glang: math functions and objects
 
 # close approximations of both E and Pi
-obj math_pi = 3.141592653589793;
-obj math_e = 2.718281828459045;
+stay math_pi = 3.141592653589793;
+stay math_e = 2.718281828459045;
 
 # convert degrees to radians
 # returns the value of degrees converted to radians

--- a/library/std/os.glang
+++ b/library/std/os.glang
@@ -10,10 +10,10 @@ func os_type() {
         obj _type = _env("OS");
 
         if _type == "Windows_NT" {
-            obj os = "windows";
+            os = "windows";
         }
     } safe _ {
-        obj os = "macos";
+        os = "macos";
     }
 
     if os == "unknown" {
@@ -57,10 +57,10 @@ func os_user_dir() {
 
     unsafe {
         # windows
-        obj dir = _env("USERPROFILE");
+        dir = _env("USERPROFILE");
     } safe _ {
         # macos
-        obj dir = _env("HOME");
+        dir = _env("HOME");
     }
 
     give dir;

--- a/library/tests/test_hashmap.glang
+++ b/library/tests/test_hashmap.glang
@@ -3,8 +3,8 @@
 fetch std_hashmap;
 
 obj test_hm = hashmap(); # create a new hashmap
-obj test_hm = hashmap_set(test_hm, "key1", "value1");
-obj test_hm = hashmap_set(test_hm, "key2", "value2");
+test_hm = hashmap_set(test_hm, "key1", "value1");
+test_hm = hashmap_set(test_hm, "key2", "value2");
 
 bark_hashmap(test_hm);
 
@@ -12,5 +12,5 @@ bark_hashmap(test_hm);
 bark(hashmap_get(test_hm, "key1"));
 
 # remove a value
-obj test_hm = hashmap_remove(test_hm, "key2");
+test_hm = hashmap_remove(test_hm, "key2");
 bark_hashmap(test_hm);


### PR DESCRIPTION
This PR updates variables and constants, with features like:

**Variable Reassignment**
```
obj x = 10;
x = 20;
```

**Constant Tracking**
```
stay TEN = 10;
obj TEN = 20; # previous version of glang allow you to do this, but this is no longer allowed
```

I also fixed the issue where interpreter errors had a duplicate `error:` line. 